### PR TITLE
Update README with license information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
-# pdf-java-toolkit-samples
+# Datalogics PDF Java Toolkit Sample repository
 
-Sample code for Datalogics PDF Java Toolkit.
+This repository contains samples for use with [Datalogics PDF Java Toolkit](http://www.datalogics.com/products/pdf/pdfjavatoolkit/).
+
+Please note that even though the samples are MIT licensed, you still require
+a license from Datalogics for PDF Java Toolkit in order to run these samples. Please
+sign up for an evaluation [here](http://www.datalogics.com/products/pdf/pdfjavatoolkit/eval/)
+or [contact us](http://www.datalogics.com/company/contact-us/) to learn more before
+evaluating Datalogics PDF Java Toolkit.


### PR DESCRIPTION
Updates to the text in the README to describe that the samples are MIT licensed and that a license from Datalogics for PDF Java Toolkit is required to be able to run the samples. Plus, provided links to the evaluation page and contact us page in case there are questions.
