### PR TITLE
Set up repo to build when checked out inside a PDFJT distribution.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,42 @@
       <version>[3.0,4.0)</version>
     </dependency>
   </dependencies>
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </snapshots>
+      <id>pdfjt</id>
+      <name>Local PDFJT repository</name>
+      <url>file://\${basedir}/../repo</url>
+      <layout>default</layout>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </snapshots>
+      <id>pdfjt</id>
+      <name>Local PDFJT repository</name>
+      <url>file://\${basedir}/../repo</url>
+      <layout>default</layout>
+    </pluginRepository>
+  </pluginRepositories>
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
- This project can be checked out inside a PDFJT distribution and
  will build and run, using that distribution's repo directory.
- Otherwise, it will attempt to get PDFJT artifacts by looking in
  repositories specified in ~/.m2/settings.xml
