### PR TITLE
DLPJT-158 Downsampling image sample patch

### DIFF
--- a/src/main/java/com/datalogics/pdf/samples/images/ImageDownsampling.java
+++ b/src/main/java/com/datalogics/pdf/samples/images/ImageDownsampling.java
@@ -34,7 +34,7 @@ import java.util.Iterator;
  * This sample demonstrates how to downsample images that are in a PDF and replace the originals with the downsampled
  * versions.
  * <p>
- * The images in the input document are down-sampled using the Nearest Neighbor downsampling method by default.
+ * The images in the input document are down-sampled using the Bicubic downsampling method by default.
  * </p>
  * Supported downsampling methods are:
  * <ul>
@@ -84,7 +84,7 @@ public final class ImageDownsampling {
 
 
     /**
-     * This method is used to downsample an image using the Resample NearestNeighbor method.
+     * This method is used to downsample an image using the Resample Bicubic method.
      *
      * @param pdfDoc PDFDocument
      * @throws PDFInvalidDocumentException a general problem with the PDF document, which may now be in an invalid state
@@ -96,7 +96,7 @@ public final class ImageDownsampling {
                     throws PDFInvalidDocumentException, PDFIOException,
                     PDFSecurityException, PDFInvalidParameterException {
         final double scaleFactor = 0.5; /* Valid range between 0-1 */
-        final int method = Resampler.kResampleNearestNeighbor;
+        final int method = Resampler.kResampleBicubic;
         /*
          * Downsample all images in the doc and replace the original images with the resampled images.
          */

--- a/src/test/java/com/datalogics/pdf/samples/images/ImageDownsamplingTest.java
+++ b/src/test/java/com/datalogics/pdf/samples/images/ImageDownsamplingTest.java
@@ -79,8 +79,8 @@ public class ImageDownsamplingTest extends SampleTest {
                 builder.imageColorSpace(ASName.k_ICCBased).imageCompression(ASName.k_DCTDecode);
 
                 // Note that you can modify the builder repeatedly and use it to make more tests.
-                add(builder.method(Resampler.kResampleNearestNeighbor)
-                           .imageChecksum("90dfd47d5e672079f5632eda8703f47d").build());
+                add(builder.method(Resampler.kResampleBicubic)
+                           .imageChecksum("f214dfd6bf398b1a66cf569350335d2c").build());
             }
         };
         return parameters;


### PR DESCRIPTION
This patch contains fixups requested by the PO. 
- Changed the Javadoc on ImageDownsample sample to clarify what it does.
- Do not allow user to pass the resampling method to ImageDownsample.main() to avoid confusion/error.
- The sample will use nearest neighbor resampling method by default.

[DLPJT-158](https://jira.datalogics.com/browse/DLPJT-158)
