### PR TITLE
DLPJTS-37 Refactor FillForm

### DIFF
--- a/src/main/java/com/datalogics/pdf/samples/forms/FillForm.java
+++ b/src/main/java/com/datalogics/pdf/samples/forms/FillForm.java
@@ -9,7 +9,6 @@ import com.adobe.internal.io.InputStreamByteReader;
 import com.adobe.pdfjt.core.license.LicenseManager;
 import com.adobe.pdfjt.pdf.document.PDFDocument;
 import com.adobe.pdfjt.pdf.document.PDFDocument.PDFDocumentType;
-import com.adobe.pdfjt.pdf.document.PDFOpenOptions;
 import com.adobe.pdfjt.services.ap.AppearanceService;
 import com.adobe.pdfjt.services.fdf.FDFDocument;
 import com.adobe.pdfjt.services.fdf.FDFService;
@@ -245,29 +244,6 @@ public final class FillForm {
         // Just save the file. Generating appearances and running calculations aren't supported for XFA forms, so
         // there's no need to try it.
         DocumentHelper.saveFullAndClose(pdfDocument, outputUrl.toURI().getPath());
-    }
-
-    /**
-     * Open a PDF file using an input path.
-     *
-     * @param inputPath The PDF file to open
-     * @return A new PDFDocument instance of the input document
-     * @throws Exception a general exception was thrown
-     */
-    public static PDFDocument openPdfDocument(final String inputPath) throws Exception {
-
-        ByteReader reader = null;
-        PDFDocument document = null;
-
-        InputStream inputStream = FillForm.class.getResourceAsStream(inputPath);
-        if (inputStream == null) {
-            inputStream = new FileInputStream(new File(inputPath));
-        }
-
-        reader = new InputStreamByteReader(inputStream);
-        document = PDFDocument.newInstance(reader, PDFOpenOptions.newInstance());
-
-        return document;
     }
 
     /**

--- a/src/test/java/com/datalogics/pdf/samples/forms/FillFormTest.java
+++ b/src/test/java/com/datalogics/pdf/samples/forms/FillFormTest.java
@@ -77,7 +77,7 @@ public class FillFormTest extends SampleTest {
         FillForm.fillAcroformFdf(inputPdfDocument, inputDataUrl, outputPdfFile.toURI().toURL());
         assertTrue(outputPdfFile.getPath() + " must exist after run", outputPdfFile.exists());
 
-        checkForms(outputPdfFile, ACROFORM_FDF_DATA);
+        checkForms(outputPdfFile.toURI().toURL(), ACROFORM_FDF_DATA);
     }
 
     @Test
@@ -91,7 +91,7 @@ public class FillFormTest extends SampleTest {
         FillForm.fillAcroformXfdf(inputPdfDocument, inputDataUrl, outputPdfFile.toURI().toURL());
 
         assertTrue(outputPdfFile.getPath() + " must exist after run", outputPdfFile.exists());
-        checkForms(outputPdfFile, ACROFORM_XFDF_DATA);
+        checkForms(outputPdfFile.toURI().toURL(), ACROFORM_XFDF_DATA);
     }
 
     @Test
@@ -105,12 +105,12 @@ public class FillFormTest extends SampleTest {
         FillForm.fillXfa(inputPdfDocument, inputDataUrl, outputPdfFile.toURI().toURL());
 
         assertTrue(outputPdfFile.getPath() + " must exist after run", outputPdfFile.exists());
-        checkForms(outputPdfFile, XFA_FORM_DATA);
+        checkForms(outputPdfFile.toURI().toURL(), XFA_FORM_DATA);
     }
 
-    private void checkForms(final File outputFile, final String compare) throws Exception {
+    private void checkForms(final URL outputFileUrl, final String compare) throws Exception {
         // Check the output doc
-        final PDFDocument outputDoc = FillForm.openPdfDocument(outputFile.getCanonicalPath());
+        final PDFDocument outputDoc = DocumentUtils.openPdfDocument(outputFileUrl);
         final PDFInteractiveForm pdfForm = outputDoc.getInteractiveForm();
         final Iterator<PDFField> fieldIterator = pdfForm.iterator();
         final StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
Refactored the FillForm sample. Preserved the way the main method works (takes in a variable number of arguments on the command line). This could be addressed in another card that has to do with the command line arguments.

Using URLs for file paths now. Also calling the business logic from the tests rather than the main method.

[DLPJTS-37](https://jira.datalogics.com/browse/DLPJTS-37)
