### PR TITLE
DLPJTS-55 Refactored the PDF/A-1b sample to use URLs instead of String for file names

### DIFF
--- a/src/main/java/com/datalogics/pdf/samples/manipulation/ConvertPdfDocument.java
+++ b/src/main/java/com/datalogics/pdf/samples/manipulation/ConvertPdfDocument.java
@@ -96,7 +96,7 @@ public final class ConvertPdfDocument {
                     throws IOException, PDFFontException, PDFInvalidDocumentException, PDFIOException,
                     PDFSecurityException, PDFInvalidParameterException, PDFUnableToCompleteOperationException {
         ByteWriter writer = null;
-        // attach font set to PDF
+        // Attach font set to PDF
         final PDFFontSet pdfaFontSet = FontSetLoader.newInstance().getFontSet();
         final PDFOpenOptions openOptions = PDFOpenOptions.newInstance();
         openOptions.setFontSet(pdfaFontSet);
@@ -111,7 +111,7 @@ public final class ConvertPdfDocument {
             if (PDFAService.convert(pdfDoc, PDFAConformanceLevel.Level_1b, options, handler)) {
                 final PDFSaveOptions saveOpt = PDFSaveFullOptions.newInstance();
 
-                // if the pdf contains compressed object streams, we should
+                // If the pdf contains compressed object streams, we should
                 // decompress these so that the pdf can be converted to PDF/A-1b
                 if (handler.requiresObjectDecompression()) {
                     saveOpt.setObjectCompressionMode(PDFSaveOptions.OBJECT_COMPRESSION_NONE);

--- a/src/test/java/com/datalogics/pdf/samples/manipulation/ConvertPdfDocumentTest.java
+++ b/src/test/java/com/datalogics/pdf/samples/manipulation/ConvertPdfDocumentTest.java
@@ -29,7 +29,7 @@ public class ConvertPdfDocumentTest extends SampleTest {
     private static final String FILE_NAME = "ConvertedPdfa-1b.pdf";
 
     @Test
-    public void testMain() throws Exception {
+    public void testConvertToPdfA1B() throws Exception {
         final URL inputUrl = ConvertPdfDocument.class.getResource(ConvertPdfDocument.INPUT_UNCONVERTED_PDF_PATH);
         final File outputFile = newOutputFileWithDelete(FILE_NAME);
         final URL outputUrl = outputFile.toURI().toURL();


### PR DESCRIPTION
This PR refactors the newly reworked ConvertPdfDocument sample to conform to our new set of file I/O guidelines.

Note that the `getByteWriterFromFile()`method added at the bottom will soon be a part of a new utility class. This will be done in DLPJTS-9.

[DLPJTS-55](https://jira.datalogics.com/browse/DLPJTS-55)
