### PR TITLE
Make relative repos work on Windows.

### DIFF
--- a/lite/pom.xml
+++ b/lite/pom.xml
@@ -105,7 +105,7 @@
       </snapshots>
       <id>pdfjt</id>
       <name>Local PDFJT repository</name>
-      <url>file://\${basedir}/../repo</url>
+      <url>${project.baseUri}../repo</url>
       <layout>default</layout>
     </repository>
   </repositories>
@@ -123,7 +123,7 @@
       </snapshots>
       <id>pdfjt</id>
       <name>Local PDFJT repository</name>
-      <url>file://\${basedir}/../repo</url>
+      <url>${project.baseUri}../repo</url>
       <layout>default</layout>
     </pluginRepository>
   </pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
       </snapshots>
       <id>pdfjt</id>
       <name>Local PDFJT repository</name>
-      <url>file://\${basedir}/../repo</url>
+      <url>${project.baseUri}../repo</url>
       <layout>default</layout>
     </repository>
   </repositories>
@@ -123,7 +123,7 @@
       </snapshots>
       <id>pdfjt</id>
       <name>Local PDFJT repository</name>
-      <url>file://\${basedir}/../repo</url>
+      <url>${project.baseUri}../repo</url>
       <layout>default</layout>
     </pluginRepository>
   </pluginRepositories>


### PR DESCRIPTION
- Trying to make a URL out of a filename doesn't work as well on Windows
  as on other platforms.
- Use project.baseUri instead of basedir
