### PR TITLE
DLPJTS-69 Ensure we handle PDFs with no text in TextExtract sample

### DIFF
--- a/src/main/java/com/datalogics/pdf/samples/extraction/TextExtract.java
+++ b/src/main/java/com/datalogics/pdf/samples/extraction/TextExtract.java
@@ -26,12 +26,16 @@ import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * This sample demonstrates how to extract text from a document. The text is extracted in reading order and then saved
  * to a text file.
  */
 public final class TextExtract {
+    private static final Logger LOGGER = Logger.getLogger(TextExtract.class.getName());
+
     public static final String INPUT_PDF_PATH = "/com/datalogics/pdf/samples/pdfjavatoolkit-ds.pdf";
     public static final String OUTPUT_TEXT_PATH = "TextExtract.txt";
 
@@ -101,9 +105,15 @@ public final class TextExtract {
             final ReadingOrderTextExtractor extractor = ReadingOrderTextExtractor.newInstance(document, docFontSet);
             final WordsIterator wordsIter = extractor.getWordsIterator();
 
-            while (wordsIter.hasNext()) {
-                final Word word = wordsIter.next();
-                outputStream.write(word.toString().getBytes("UTF-8"));
+            if (wordsIter.hasNext()) {
+                do {
+                    final Word word = wordsIter.next();
+                    outputStream.write(word.toString().getBytes("UTF-8"));
+                } while (wordsIter.hasNext());
+            } else {
+                if (LOGGER.isLoggable(Level.INFO)) {
+                    LOGGER.info(inputUrl.getFile() + " did not have any text to extract.");
+                }
             }
 
         } finally {

--- a/src/main/java/com/datalogics/pdf/samples/extraction/TextExtract.java
+++ b/src/main/java/com/datalogics/pdf/samples/extraction/TextExtract.java
@@ -82,10 +82,12 @@ public final class TextExtract {
      * @throws UnsupportedEncodingException the character encoding is not supported
      * @throws IOException an I/O operation failed or was interrupted
      * @throws PDFUnableToCompleteOperationException the operation was unable to be completed
+     * @throws URISyntaxException the input URL could not be converted to a string
      */
     public static void extractTextReadingOrder(final URL inputUrl, final URL outputUrl)
                     throws PDFInvalidDocumentException, PDFIOException, PDFFontException, PDFSecurityException,
-                    UnsupportedEncodingException, IOException, PDFUnableToCompleteOperationException {
+                    UnsupportedEncodingException, IOException, PDFUnableToCompleteOperationException,
+                    URISyntaxException {
         PDFDocument document = null;
         try {
             document = DocumentUtils.openPdfDocument(inputUrl);
@@ -103,7 +105,7 @@ public final class TextExtract {
                 }
             } else {
                 if (LOGGER.isLoggable(Level.INFO)) {
-                    LOGGER.info(inputUrl.getFile() + " did not have any text to extract.");
+                    LOGGER.info(inputUrl.toURI().getPath() + " did not have any text to extract.");
                 }
             }
 

--- a/src/test/java/com/datalogics/pdf/samples/extraction/TextExtractTest.java
+++ b/src/test/java/com/datalogics/pdf/samples/extraction/TextExtractTest.java
@@ -83,12 +83,13 @@ public class TextExtractTest extends SampleTest {
         // Verify that we got the expected log message
         assertEquals("Must have one log record", 1, logRecords.size());
         final LogRecord logRecord = logRecords.get(0);
-        assertEquals(inputUrl.getFile() + " did not have any text to extract.", logRecord.getMessage());
+        assertEquals(inputUrl.toURI().getPath() + " did not have any text to extract.", logRecord.getMessage());
         assertEquals(Level.INFO, logRecord.getLevel());
 
         // Verify that the output file was not created
         final Path path = Paths.get(outputUrl.getPath());
-        assertTrue(outputUrl.getFile() + " should not exist.", Files.notExists(path, LinkOption.NOFOLLOW_LINKS));
+        assertTrue(outputUrl.toURI().getPath() + " should not exist.",
+                   Files.notExists(path, LinkOption.NOFOLLOW_LINKS));
     }
 
     /*

--- a/src/test/java/com/datalogics/pdf/samples/extraction/TextExtractTest.java
+++ b/src/test/java/com/datalogics/pdf/samples/extraction/TextExtractTest.java
@@ -7,13 +7,35 @@ package com.datalogics.pdf.samples.extraction;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.adobe.internal.io.ByteWriter;
+import com.adobe.internal.io.RandomAccessFileByteWriter;
+import com.adobe.pdfjt.core.exceptions.PDFIOException;
+import com.adobe.pdfjt.core.exceptions.PDFInvalidDocumentException;
+import com.adobe.pdfjt.core.exceptions.PDFSecurityException;
+import com.adobe.pdfjt.core.types.ASRectangle;
+import com.adobe.pdfjt.pdf.document.PDFDocument;
+import com.adobe.pdfjt.pdf.document.PDFOpenOptions;
+import com.adobe.pdfjt.pdf.document.PDFSaveFullOptions;
+import com.adobe.pdfjt.pdf.graphics.PDFRectangle;
+import com.adobe.pdfjt.pdf.page.PDFPage;
+import com.adobe.pdfjt.pdf.page.PDFPageTree;
+
 import com.datalogics.pdf.samples.SampleTest;
+import com.datalogics.pdf.samples.util.LogRecordListCollector;
 
 import org.junit.Test;
 
 import java.io.File;
+import java.io.RandomAccessFile;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 /**
  * Tests the TextExtract sample.
@@ -23,6 +45,8 @@ public class TextExtractTest extends SampleTest {
     private static final String OUTPUT_FILE_PATH = "TextExtractTest.txt";
     private static final String INPUT_PDF_PATH = "/com/datalogics/pdf/samples/pdfjavatoolkit-ds.pdf";
     private static final String EXTRACTED_DOCUMENT_NAME = "TextExtractTest-ReadingOrder.txt";
+    private static final String EMPTY_PDF_FILE_PATH = "Empty.pdf";
+    private static final String EMPTY_TEXT_FILE_PATH = "Empty.txt";
 
     @Test
     public void testExtractTextReadingOrder() throws Exception {
@@ -39,5 +63,47 @@ public class TextExtractTest extends SampleTest {
 
         final String extractedText = contentsOfTextFile(file);
         assertEquals(contentsOfResource(EXTRACTED_DOCUMENT_NAME), extractedText);
+    }
+
+    @Test
+    public void testDocumentWithNoText() throws Exception {
+        // Create a new document with a single empty page
+        final PDFDocument document = createEmptyPdf();
+        final File emptyPdf = newOutputFileWithDelete(EMPTY_PDF_FILE_PATH);
+        final RandomAccessFile outputPdfFile = new RandomAccessFile(emptyPdf, "rw");
+        final ByteWriter outputWriter = new RandomAccessFileByteWriter(outputPdfFile);
+        document.saveAndClose(outputWriter, PDFSaveFullOptions.newInstance());
+
+        final File emptyTxt = newOutputFileWithDelete(EMPTY_TEXT_FILE_PATH);
+
+        final URL inputUrl = emptyPdf.toURI().toURL();
+        final URL outputUrl = emptyTxt.toURI().toURL();
+
+        final ArrayList<LogRecord> logRecords = new ArrayList<LogRecord>();
+        final Logger logger = Logger.getLogger(TextExtract.class.getName());
+        try (LogRecordListCollector collector = new LogRecordListCollector(logger, logRecords)) {
+            TextExtract.extractTextReadingOrder(inputUrl, outputUrl);
+        }
+
+        // Verify that we got the expected log message
+        assertEquals("Must have one log record", 1, logRecords.size());
+        final LogRecord logRecord = logRecords.get(0);
+        assertEquals(inputUrl.getFile() + " did not have any text to extract.", logRecord.getMessage());
+        assertEquals(Level.INFO, logRecord.getLevel());
+
+        // Verify that the output file was not created
+        final Path path = Paths.get(outputUrl.getPath());
+        assertTrue(outputUrl.getFile() + " should not exist.", Files.notExists(path, LinkOption.NOFOLLOW_LINKS));
+    }
+
+    /*
+     * Create a PDF with a single blank page, for testing.
+     */
+    private static PDFDocument createEmptyPdf() throws PDFInvalidDocumentException, PDFIOException,
+                    PDFSecurityException {
+        final PDFDocument document = PDFDocument.newInstance(PDFOpenOptions.newInstance());
+        final PDFPage page = PDFPage.newInstance(document, PDFRectangle.newInstance(document, ASRectangle.US_LETTER));
+        PDFPageTree.newInstance(document, page);
+        return document;
     }
 }

--- a/src/test/java/com/datalogics/pdf/samples/extraction/TextExtractTest.java
+++ b/src/test/java/com/datalogics/pdf/samples/extraction/TextExtractTest.java
@@ -7,26 +7,23 @@ package com.datalogics.pdf.samples.extraction;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.adobe.internal.io.ByteWriter;
-import com.adobe.internal.io.RandomAccessFileByteWriter;
 import com.adobe.pdfjt.core.exceptions.PDFIOException;
 import com.adobe.pdfjt.core.exceptions.PDFInvalidDocumentException;
 import com.adobe.pdfjt.core.exceptions.PDFSecurityException;
 import com.adobe.pdfjt.core.types.ASRectangle;
 import com.adobe.pdfjt.pdf.document.PDFDocument;
 import com.adobe.pdfjt.pdf.document.PDFOpenOptions;
-import com.adobe.pdfjt.pdf.document.PDFSaveFullOptions;
 import com.adobe.pdfjt.pdf.graphics.PDFRectangle;
 import com.adobe.pdfjt.pdf.page.PDFPage;
 import com.adobe.pdfjt.pdf.page.PDFPageTree;
 
+import com.datalogics.pdf.document.DocumentHelper;
 import com.datalogics.pdf.samples.SampleTest;
 import com.datalogics.pdf.samples.util.LogRecordListCollector;
 
 import org.junit.Test;
 
 import java.io.File;
-import java.io.RandomAccessFile;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -70,9 +67,7 @@ public class TextExtractTest extends SampleTest {
         // Create a new document with a single empty page
         final PDFDocument document = createEmptyPdf();
         final File emptyPdf = newOutputFileWithDelete(EMPTY_PDF_FILE_PATH);
-        final RandomAccessFile outputPdfFile = new RandomAccessFile(emptyPdf, "rw");
-        final ByteWriter outputWriter = new RandomAccessFileByteWriter(outputPdfFile);
-        document.saveAndClose(outputWriter, PDFSaveFullOptions.newInstance());
+        DocumentHelper.saveFullAndClose(document, emptyPdf.getCanonicalPath());
 
         final File emptyTxt = newOutputFileWithDelete(EMPTY_TEXT_FILE_PATH);
 

--- a/src/test/java/com/datalogics/pdf/samples/util/LogRecordListCollector.java
+++ b/src/test/java/com/datalogics/pdf/samples/util/LogRecordListCollector.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015 Datalogics, Inc.
+ */
+
+package com.datalogics.pdf.samples.util;
+
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+public class LogRecordListCollector implements AutoCloseable {
+    private static class LogRecordHandler extends Handler {
+        private final List<LogRecord> logRecordList;
+
+        /**
+         * Create a handler that records records to a list.
+         *
+         * @param logRecordList the list to receive the log records.
+         */
+        public LogRecordHandler(final List<LogRecord> logRecordList) {
+            super();
+            this.logRecordList = logRecordList;
+        }
+
+        /*
+         * (non-Javadoc)
+         * 
+         * @see java.util.logging.Handler#publish(java.util.logging.LogRecord)
+         */
+        @Override
+        public void publish(final LogRecord record) {
+            logRecordList.add(record);
+        }
+
+        /*
+         * (non-Javadoc)
+         * 
+         * @see java.util.logging.Handler#flush()
+         */
+        @Override
+        public void flush() {}
+
+        /*
+         * (non-Javadoc)
+         * 
+         * @see java.util.logging.Handler#close()
+         */
+        @Override
+        public void close() throws SecurityException {}
+    }
+
+    private final Logger targetLogger;
+    private final Handler handler;
+
+
+    /**
+     * Make a list of every {@link LogRecord} sent to a {@link Logger}.
+     *
+     * @param targetLogger the logger to monitor
+     * @param logRecordList a list to receive the
+     */
+    public LogRecordListCollector(final Logger targetLogger, final List<LogRecord> logRecordList) {
+        super();
+        this.targetLogger = targetLogger;
+        this.handler = new LogRecordHandler(logRecordList);
+        this.handler.setLevel(Level.ALL);
+        this.targetLogger.addHandler(this.handler);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see java.lang.AutoCloseable#close()
+     */
+    @Override
+    public void close() throws Exception {
+        targetLogger.removeHandler(handler);
+    }
+
+}


### PR DESCRIPTION
If the TextExtract sample is supplied a PDF with no text (e.g. it only has images), log the absence of any text, and make sure we don't produce an empty output file.

[DLPJTS-69](https://jira.datalogics.com/browse/DLPJTS-69)
