### PR TITLE
PDFJT-796 Use new setInteriorColor() method that takes array of doubles.

### DIFF
--- a/src/main/java/com/datalogics/pdf/samples/manipulation/RedactAndSanitizeDocument.java
+++ b/src/main/java/com/datalogics/pdf/samples/manipulation/RedactAndSanitizeDocument.java
@@ -243,7 +243,7 @@ public final class RedactAndSanitizeDocument {
         annot.setQuads(word.getBoundingQuads());
         annot.setRect(annot.getRedactionAreaBBox());
         annot.setColor(COLOR);
-        annot.setInteriorColor(INTERIOR_COLOR[0], INTERIOR_COLOR[1], INTERIOR_COLOR[2]);
+        annot.setInteriorColor(INTERIOR_COLOR);
 
         // Set the Annotation's creation and modification date.
         final ASDate now = new ASDate();


### PR DESCRIPTION
#### Please make sure that [PR#891](https://octocat.dlogics.com/datalogics/pdf-java-toolkit/pull/891) is merged before merging this.

This is a PR to fixup the RedactAndSanitizeDocument sample to use the new setInteriorColor() method that takes an array of doubles.

[PDFJT-796](https://jira.datalogics.com/browse/PDFJT-796)
