### PR TITLE
DLPJTS-75 Fix the issue with TextExtractTest on Windows.

### DIFF
--- a/src/test/java/com/datalogics/pdf/samples/extraction/TextExtractTest.java
+++ b/src/test/java/com/datalogics/pdf/samples/extraction/TextExtractTest.java
@@ -87,7 +87,7 @@ public class TextExtractTest extends SampleTest {
         assertEquals(Level.INFO, logRecord.getLevel());
 
         // Verify that the output file was not created
-        final Path path = Paths.get(outputUrl.getPath());
+        final Path path = Paths.get(outputUrl.toURI());
         assertTrue(outputUrl.toURI().getPath() + " should not exist.",
                    Files.notExists(path, LinkOption.NOFOLLOW_LINKS));
     }


### PR DESCRIPTION
This fix passes the file path for the empty text file as a URI to
the Paths.get() method.

[DLPJTS-75](https://jira.datalogics.com/browse/DLPJTS-75)
