### PR TITLE
DLPJTS-92 Be able to build with Talkeetna 5 or 6

### DIFF
--- a/lite/pom.xml
+++ b/lite/pom.xml
@@ -760,6 +760,28 @@
         </pluginRepository>
       </pluginRepositories>
     </profile>
+    <profile>
+      <id>use-talkeetna-6</id>
+      <activation>
+        <file>
+          <exists>${basedir}/.use-talkeetna-6</exists>
+        </file>
+      </activation>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>com.datalogics.pdf</groupId>
+            <artifactId>talkeetna</artifactId>
+            <version>[6.0.0-SNAPSHOT,7.0.0-SNAPSHOT)</version>
+          </dependency>
+          <dependency>
+            <groupId>com.datalogics.pdf</groupId>
+            <artifactId>talkeetna-lm</artifactId>
+            <version>[6.0.0-SNAPSHOT,7.0.0-SNAPSHOT)</version>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
   </profiles>
 </project>
 <!-- vim: set et sts=2 sw=2 ts=2 : -->

--- a/pom.xml
+++ b/pom.xml
@@ -557,6 +557,28 @@
         </pluginRepository>
       </pluginRepositories>
     </profile>
+    <profile>
+      <id>use-talkeetna-6</id>
+      <activation>
+        <file>
+          <exists>${basedir}/.use-talkeetna-6</exists>
+        </file>
+      </activation>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>com.datalogics.pdf</groupId>
+            <artifactId>talkeetna</artifactId>
+            <version>[6.0.0-SNAPSHOT,7.0.0-SNAPSHOT)</version>
+          </dependency>
+          <dependency>
+            <groupId>com.datalogics.pdf</groupId>
+            <artifactId>talkeetna-lm</artifactId>
+            <version>[6.0.0-SNAPSHOT,7.0.0-SNAPSHOT)</version>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
   </profiles>
 </project>
 <!-- vim: set et sts=2 sw=2 ts=2 : -->

--- a/src/main/java/com/datalogics/pdf/samples/signature/SignDocument.java
+++ b/src/main/java/com/datalogics/pdf/samples/signature/SignDocument.java
@@ -21,6 +21,8 @@ import com.adobe.pdfjt.services.digsig.UserInfo;
 import com.datalogics.pdf.samples.util.DocumentUtils;
 import com.datalogics.pdf.samples.util.IoUtils;
 
+import org.apache.commons.io.IOUtils;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -176,13 +178,6 @@ public final class SignDocument {
     }
 
     private static byte[] getDerEncodedData(final InputStream inputStream) throws IOException {
-        final byte[] derData = new byte[inputStream.available()];
-        final int totalBytes = inputStream.read(derData, 0, derData.length);
-        if (totalBytes == 0) {
-            LOGGER.info("getDerEncodedData(): No bytes read from InputStream");
-        }
-        inputStream.close();
-
-        return derData;
+        return IOUtils.toByteArray(inputStream);
     }
 }


### PR DESCRIPTION
#### Changes in this pull request
- The presence of the `.use-talkeetna-6` directory will change the dependency to use Talkeetna 6.x, which implies the use of the new PDFJT 4.0.
- This can also be triggered by activating the `use-talkeetna-6` profile with `-Puse-talkeetna-6`
#### Fulfills  [DLPJTS-92](https://jira.datalogics.com/browse/DLPJTS-92)
#### Checklist for approving this pull request

(PR creator amend this with more conditions if necessary)
- [x] There are **unit tests** for new/changed code, or a good explanation why this was not possible.
- [x] All **CI builders** have indicated success (Give them a few minutes to notice the pull request.)
- [x] The **Pull request title** has the JIRA issue numbers separated by spaces (if any), a space, and then a short, but descriptive summary.
- [x] **Commit messages** are well formed: [A note about Git commit messages](http://www.tpope.net/node/106)
- [x] New public packages, classes, and methods are **documented**. (Strongly consider documenting private classes and methods.)
#### Blockers

Add a checkbox for yourself with your **&#64;name** to this list if you are holding this PR open for review. PR Shepherd, please hold off merging this PR until these are all checked:
- [x] _&lt;add your name here with an **@**>_
