### PR TITLE
[WIP] Generate appearances before removing interactive elements

### DIFF
--- a/src/main/java/com/datalogics/pdf/samples/manipulation/RemoveInteractivity.java
+++ b/src/main/java/com/datalogics/pdf/samples/manipulation/RemoveInteractivity.java
@@ -15,6 +15,7 @@ import com.adobe.pdfjt.core.exceptions.PDFUnsupportedFeatureException;
 import com.adobe.pdfjt.core.license.LicenseManager;
 import com.adobe.pdfjt.pdf.document.PDFDocument;
 import com.adobe.pdfjt.pdf.interactive.annotation.PDFAnnotationEnum;
+import com.adobe.pdfjt.services.ap.AppearanceService;
 import com.adobe.pdfjt.services.ap.spi.APContext;
 import com.adobe.pdfjt.services.ap.spi.APResources;
 import com.adobe.pdfjt.services.digsig.SignatureManager;
@@ -126,6 +127,10 @@ public final class RemoveInteractivity {
 
         try {
             pdfDoc = DocumentUtils.openPdfDocument(inputUrl);
+
+            // Before removing any interactive elements, generate their appearances using the AppearanceService
+            // to ensure that the document has all required appearances so the document looks correct at the end.
+            AppearanceService.generateAppearances(pdfDoc, null, null);
 
             // Remove interactivity of the signature fields so they can no longer be changed. Omit the next two lines
             // if you want to preserve signature interactivity.


### PR DESCRIPTION
Before removing the interactive elements from a document, generate the appearances for them so that it can be included in the page content. 

This ensures that form fields come out looking correct and probably some other things as well.

This came out of a POC that I am working on for sales that demonstrates removing interactivity from a document and then printing it.

#### Changes in this pull request

- Call AppearanceService.generateAppearances() before flattening signatures or forms

#### Checklist for approving this pull request

(PR creator amend this with more conditions if necessary)

- [ ] There are **unit tests** for new/changed code, or a good explanation why this was not possible.
- [ ] All **CI builders** have indicated success (Give them a few minutes to notice the pull request.)
- [ ] The **Pull request title** has the JIRA issue numbers separated by spaces (if any), a space, and then a short, but descriptive summary.
- [ ] **Commit messages** are well formed: [A note about Git commit messages](http://www.tpope.net/node/106)
- [ ] New public packages, classes, and methods are **documented**. (Strongly consider documenting private classes and methods.)

#### Blockers

Add a checkbox for yourself with your **&#64;name** to this list if you are holding this PR open for review. PR Shepherd, please hold off merging this PR until these are all checked:

- [x] _&lt;add your name here with an **@**>_
