### PR TITLE
[WIP] Add start of ConvertAcroFormToHtml sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -342,6 +342,7 @@ gradle-app.setting
 /Demo2Pg.txt
 /TextExtract.txt
 /*.csv
+/*.html
 
 # The FindBugs connector for M2Eclipse makes these
 .fbExcludeFilterFile

--- a/pom.xml
+++ b/pom.xml
@@ -175,9 +175,11 @@
           <target>1.7</target>
           <excludes>
             <exclude>com/datalogics/pdf/samples/extraction/TextCharacterBoxes.java</exclude>
+            <exclude>com/datalogics/pdf/samples/forms/ConvertAcroFormToHtml.java</exclude>
           </excludes>
           <testExcludes>
             <testExclude>com/datalogics/pdf/samples/extraction/TextCharacterBoxesTest.java</testExclude>
+            <exclude>com/datalogics/pdf/samples/forms/ConvertAcroFormToHtmlTest.java</exclude>
           </testExcludes>
         </configuration>
       </plugin>
@@ -202,6 +204,7 @@
           </docletArtifact>
           <sourceFileExcludes>
             <sourceFileExclude>**/TextCharacterBoxes.java</sourceFileExclude>
+            <sourceFileExclude>**/ConvertAcroFormToHtml.java</sourceFileExclude>
           </sourceFileExcludes>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,12 @@
       <artifactId>htmlflow</artifactId>
       <version>1.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+      <version>1.10.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
       <version>3.5</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.fmcarvalho</groupId>
+      <artifactId>htmlflow</artifactId>
+      <version>1.1</version>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/src/main/java/com/datalogics/pdf/samples/forms/ConvertAcroFormToHtml.java
+++ b/src/main/java/com/datalogics/pdf/samples/forms/ConvertAcroFormToHtml.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 Datalogics, Inc.
+ */
+
+package com.datalogics.pdf.samples.forms;
+
+import com.adobe.pdfjt.core.license.LicenseManager;
+
+import com.datalogics.pdf.samples.util.IoUtils;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.logging.Logger;
+
+/**
+ * This sample demonstrates how to create an HTML form by inspecting an AcroForm in a PDF.
+ */
+public class ConvertAcroFormToHtml {
+    public static final String DEFAULT_INPUT = "acroform_fdf.pdf";
+    public static final String HTML_OUTPUT = "acroform.html";
+
+    private static final Logger LOGGER = Logger.getLogger(ConvertAcroFormToHtml.class.getName());
+
+    /**
+     * This is a utility class, and won't be instantiated.
+     */
+    private ConvertAcroFormToHtml() {}
+
+    /**
+     * @param args
+     * @throws MalformedURLException
+     */
+    public static void main(final String[] args) throws MalformedURLException {
+        // If you are using an evaluation version of the product (License Managed, or LM), set the path to where PDFJT
+        // can find the license file.
+        //
+        // If you are not using an evaluation version of the product you can ignore or remove this code.
+        LicenseManager.setLicensePath(".");
+
+        URL inputUrl = null;
+        URL outputUrl = null;
+        if (args.length > 0) {
+            inputUrl = IoUtils.createUrlFromPath(args[0]);
+            outputUrl = IoUtils.createUrlFromPath(args[1]);
+        } else {
+            inputUrl = ExportFormDataToCsv.class.getResource(DEFAULT_INPUT);
+            outputUrl = IoUtils.createUrlFromPath(HTML_OUTPUT);
+        }
+
+        createHtmlForm(inputUrl, outputUrl);
+    }
+
+    /**
+     * Create an HTML form from the AcroForm found in the PDF specified by inputUrl.
+     *
+     * @param inputUrl
+     * @param outputUrl
+     */
+    public static void createHtmlForm(final URL inputUrl, final URL outputUrl) {
+    }
+}

--- a/src/main/java/com/datalogics/pdf/samples/forms/ConvertAcroFormToHtml.java
+++ b/src/main/java/com/datalogics/pdf/samples/forms/ConvertAcroFormToHtml.java
@@ -11,6 +11,7 @@ import com.adobe.pdfjt.core.exceptions.PDFUnableToCompleteOperationException;
 import com.adobe.pdfjt.core.license.LicenseManager;
 import com.adobe.pdfjt.pdf.document.PDFDocument;
 import com.adobe.pdfjt.pdf.interactive.forms.PDFField;
+import com.adobe.pdfjt.pdf.interactive.forms.PDFFieldChoice;
 import com.adobe.pdfjt.pdf.interactive.forms.PDFFieldType;
 import com.adobe.pdfjt.pdf.interactive.forms.PDFInteractiveForm;
 
@@ -27,6 +28,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.util.Iterator;
+import java.util.List;
 import java.util.logging.Logger;
 
 /**
@@ -119,6 +121,11 @@ public class ConvertAcroFormToHtml {
                     htmlForm.text(field.getQualifiedName())
                             // use the qualified name as the name of the field in the Html form as well
                             .inputText(field.getQualifiedName()).br();
+                } else if (fieldType == PDFFieldType.Choice) {
+                    final PDFFieldChoice choiceField = (PDFFieldChoice) field;
+                    final List<?> optionsList = choiceField.getOptionList();
+                    final String[] options = optionsList.toArray(new String[optionsList.size()]);
+                    htmlForm.text(field.getQualifiedName()).select(field.getQualifiedName(), options).br();
                 } else {
                     // log a warning if a field was not output because a matching type was not found
                     LOGGER.warning(field.getQualifiedName() + " was not output in the Html form!");

--- a/src/main/java/com/datalogics/pdf/samples/forms/ConvertAcroFormToHtml.java
+++ b/src/main/java/com/datalogics/pdf/samples/forms/ConvertAcroFormToHtml.java
@@ -8,8 +8,14 @@ import com.adobe.pdfjt.core.license.LicenseManager;
 
 import com.datalogics.pdf.samples.util.IoUtils;
 
-import java.net.MalformedURLException;
+import htmlflow.HtmlView;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.logging.Logger;
 
 /**
@@ -28,9 +34,10 @@ public class ConvertAcroFormToHtml {
 
     /**
      * @param args
-     * @throws MalformedURLException
+     * @throws IOException
+     * @throws URISyntaxException
      */
-    public static void main(final String[] args) throws MalformedURLException {
+    public static void main(final String[] args) throws URISyntaxException, IOException {
         // If you are using an evaluation version of the product (License Managed, or LM), set the path to where PDFJT
         // can find the license file.
         //
@@ -55,7 +62,35 @@ public class ConvertAcroFormToHtml {
      *
      * @param inputUrl
      * @param outputUrl
+     * @throws URISyntaxException
+     * @throws IOException
      */
-    public static void createHtmlForm(final URL inputUrl, final URL outputUrl) {
+    public static void createHtmlForm(final URL inputUrl, final URL outputUrl) throws URISyntaxException, IOException {
+        // Use the sample code from the README of HtmlFlow as a starting point
+        // https://github.com/fmcarvalho/HtmlFlow/blob/master/Readme.md
+        final HtmlView<?> taskView = new HtmlView<>();
+        taskView
+                .head()
+                .title("Task Details")
+                .linkCss("https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css");
+        taskView
+                .body().classAttr("container")
+                .heading(1, "Task Details")
+                .hr()
+                .div()
+                .text("Title: ").text("ISEL MPD project")
+                .br()
+                .text("Description: ").text("A Java library for serializing objects in HTML.")
+                .br()
+                .text("Priority: ").text("HIGH");
+
+        final File outputFile = new File(outputUrl.toURI());
+        if (outputFile.exists()) {
+            Files.delete(outputFile.toPath());
+        }
+
+        try (PrintStream out = new PrintStream(outputFile)) {
+            taskView.setPrintStream(out).write();
+        }
     }
 }

--- a/src/main/java/com/datalogics/pdf/samples/forms/ConvertAcroFormToHtml.java
+++ b/src/main/java/com/datalogics/pdf/samples/forms/ConvertAcroFormToHtml.java
@@ -11,6 +11,7 @@ import com.adobe.pdfjt.core.exceptions.PDFUnableToCompleteOperationException;
 import com.adobe.pdfjt.core.license.LicenseManager;
 import com.adobe.pdfjt.pdf.document.PDFDocument;
 import com.adobe.pdfjt.pdf.interactive.forms.PDFField;
+import com.adobe.pdfjt.pdf.interactive.forms.PDFFieldType;
 import com.adobe.pdfjt.pdf.interactive.forms.PDFInteractiveForm;
 
 import com.datalogics.pdf.samples.util.DocumentUtils;
@@ -109,11 +110,19 @@ public class ConvertAcroFormToHtml {
             // add each field from the Pdf form to the Html form
             while (fieldIterator.hasNext()) {
                 final PDFField field = fieldIterator.next();
-                // output the qualified name of the field in the Pdf as text before the field
-                // in the Html form so the user knows what the field is for
-                htmlForm.text(field.getQualifiedName())
-                        // use the qualified name as the name of the field in the Html form as well
-                        .inputText(field.getQualifiedName());
+
+                // determine what Html element should be used based on the type of field in the Pdf form
+                final PDFFieldType fieldType = field.getFieldType();
+                if (fieldType == PDFFieldType.Text) {
+                    // output the qualified name of the field in the Pdf as text before the field
+                    // in the Html form so the user knows what the field is for
+                    htmlForm.text(field.getQualifiedName())
+                            // use the qualified name as the name of the field in the Html form as well
+                            .inputText(field.getQualifiedName()).br();
+                } else {
+                    // log a warning if a field was not output because a matching type was not found
+                    LOGGER.warning(field.getQualifiedName() + " was not output in the Html form!");
+                }
             }
 
             final File outputFile = new File(outputUrl.toURI());

--- a/src/main/java/com/datalogics/pdf/samples/forms/ConvertAcroFormToHtml.java
+++ b/src/main/java/com/datalogics/pdf/samples/forms/ConvertAcroFormToHtml.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 /**
  * This sample demonstrates how to create an HTML form by inspecting an AcroForm in a PDF.
  */
-public class ConvertAcroFormToHtml {
+public final class ConvertAcroFormToHtml {
     public static final String DEFAULT_INPUT = "acroform_fdf.pdf";
     public static final String HTML_OUTPUT = "acroform.html";
 

--- a/src/test/java/com/datalogics/pdf/samples/forms/ConvertAcroFormToHtmlTest.java
+++ b/src/test/java/com/datalogics/pdf/samples/forms/ConvertAcroFormToHtmlTest.java
@@ -4,10 +4,15 @@
 
 package com.datalogics.pdf.samples.forms;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.datalogics.pdf.samples.SampleTest;
 
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 import org.junit.Test;
 
 import java.io.File;
@@ -17,6 +22,7 @@ import java.net.URL;
  * Tests the ConvertAcroFormToHtml sample.
  */
 public class ConvertAcroFormToHtmlTest extends SampleTest {
+    private static final String HTML_TITLE = "FruitForm_1";
     @Test
     public void testConvertAcroFormToHtmlWithDefaultSampleInput() throws Exception {
         final URL inputUrl = ConvertAcroFormToHtml.class.getResource(ConvertAcroFormToHtml.DEFAULT_INPUT);
@@ -25,5 +31,13 @@ public class ConvertAcroFormToHtmlTest extends SampleTest {
         ConvertAcroFormToHtml.createHtmlForm(inputUrl, outputHtmlFile.toURI().toURL());
         assertTrue(outputHtmlFile.getPath() + " must exist after run", outputHtmlFile.exists());
 
+        final Document htmlDocument = Jsoup.parse(outputHtmlFile, "UTF-8");
+
+        final Elements headTitleElements = htmlDocument.head().getElementsByTag("title");
+        assertEquals("Only one title element should be found in the head of the Html",
+                     headTitleElements.size(), 1);
+
+        final Element headTitle = headTitleElements.get(0);
+        assertEquals("Title of the Html output should be " + HTML_TITLE, HTML_TITLE, headTitle.text());
     }
 }

--- a/src/test/java/com/datalogics/pdf/samples/forms/ConvertAcroFormToHtmlTest.java
+++ b/src/test/java/com/datalogics/pdf/samples/forms/ConvertAcroFormToHtmlTest.java
@@ -12,17 +12,38 @@ import com.datalogics.pdf.samples.SampleTest;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.jsoup.nodes.FormElement;
 import org.jsoup.select.Elements;
 import org.junit.Test;
 
 import java.io.File;
 import java.net.URL;
+import java.util.ArrayList;
 
 /**
  * Tests the ConvertAcroFormToHtml sample.
  */
 public class ConvertAcroFormToHtmlTest extends SampleTest {
     private static final String HTML_TITLE = "FruitForm_1";
+    private static final ArrayList<String> DEFAULT_SAMPLE_OUTPUT_HTML_INPUT_ELEMENTS = new ArrayList<String>() {
+        private static final long serialVersionUID = -8806374175991455410L;
+
+        {
+            add("accountNumber");
+            add("name");
+            add("address");
+            add("city");
+            add("state");
+            add("zip");
+            add("phone");
+            add("email");
+            add("quantity");
+            add("cost");
+            add("deliveryCharge");
+            add("total");
+        }
+    };
+
     @Test
     public void testConvertAcroFormToHtmlWithDefaultSampleInput() throws Exception {
         final URL inputUrl = ConvertAcroFormToHtml.class.getResource(ConvertAcroFormToHtml.DEFAULT_INPUT);
@@ -39,5 +60,17 @@ public class ConvertAcroFormToHtmlTest extends SampleTest {
 
         final Element headTitle = headTitleElements.get(0);
         assertEquals("Title of the Html output should be " + HTML_TITLE, HTML_TITLE, headTitle.text());
+
+        final Elements formElements = htmlDocument.body().getElementsByTag("form");
+        assertEquals("Only one form element should be found in the body of the Html", formElements.size(), 1);
+
+        final FormElement form = (FormElement) formElements.get(0);
+        final Elements formInputElements = form.getElementsByTag("input");
+        assertEquals(formInputElements.size(), DEFAULT_SAMPLE_OUTPUT_HTML_INPUT_ELEMENTS.size());
+
+        for (final Element e : formInputElements) {
+            assertTrue("Element " + e.attr("name") + " was not found in Html Form",
+                       DEFAULT_SAMPLE_OUTPUT_HTML_INPUT_ELEMENTS.contains(e.attr("name")));
+        }
     }
 }

--- a/src/test/java/com/datalogics/pdf/samples/forms/ConvertAcroFormToHtmlTest.java
+++ b/src/test/java/com/datalogics/pdf/samples/forms/ConvertAcroFormToHtmlTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 Datalogics, Inc.
+ */
+
+package com.datalogics.pdf.samples.forms;
+
+import static org.junit.Assert.assertTrue;
+
+import com.datalogics.pdf.samples.SampleTest;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URL;
+
+/**
+ * Tests the ConvertAcroFormToHtml sample.
+ */
+public class ConvertAcroFormToHtmlTest extends SampleTest {
+    @Test
+    public void testConvertAcroFormToHtmlWithDefaultSampleInput() throws Exception {
+        final URL inputUrl = ConvertAcroFormToHtml.class.getResource(ConvertAcroFormToHtml.DEFAULT_INPUT);
+
+        final File outputHtmlFile = newOutputFileWithDelete(ConvertAcroFormToHtml.HTML_OUTPUT);
+        ConvertAcroFormToHtml.createHtmlForm(inputUrl, outputHtmlFile.toURI().toURL());
+        assertTrue(outputHtmlFile.getPath() + " must exist after run", outputHtmlFile.exists());
+
+    }
+}


### PR DESCRIPTION
Work in progress for June 2017 blog post for Datalogics PDF Java Toolkit. This idea came out of a question received from a current customer who asked about doing this very thing so that they could present a form online (without worrying about browser support for filling in PDF forms) and still have a PDF on the backend.

#### Changes in this pull request

- Provide a sample that converts an AcroForm to an HTML form

#### Checklist for approving this pull request

- [ ] There are **unit tests** for new/changed code, or a good explanation why this was not possible.
- [ ] All **CI builders** have indicated success (Give them a few minutes to notice the pull request.)
- [ ] The **Pull request title** has the JIRA issue numbers separated by spaces (if any), a space, and then a short, but descriptive summary.
- [ ] **Commit messages** are well formed: [A note about Git commit messages](http://www.tpope.net/node/106)
- [ ] New public packages, classes, and methods are **documented**. (Strongly consider documenting private classes and methods.)

#### Blockers

Add a checkbox for yourself with your **&#64;name** to this list if you are holding this PR open for review. PR Shepherd, please hold off merging this PR until these are all checked:

- [x] _&lt;add your name here with an **@**>_
