### PR TITLE
DLPJTS-115 Supply fonts when signing

### DIFF
--- a/src/main/java/com/datalogics/pdf/samples/signature/SignDocument.java
+++ b/src/main/java/com/datalogics/pdf/samples/signature/SignDocument.java
@@ -222,8 +222,8 @@ public final class SignDocument {
     private static SignatureAppearanceDisplayItemsSet createSignatureAppearanceDisplayItemsSet() {
         final SignatureAppearanceDisplayItemsSet displayItems = SignatureAppearanceDisplayItemsSet.newInstance();
 
-        // Show nothing
-        displayItems.disable(SignatureAppearanceDisplayItemsSet.kShowAll);
+        // Show everything
+        displayItems.enable(SignatureAppearanceDisplayItemsSet.kShowAll);
         return displayItems;
     }
 


### PR DESCRIPTION
#### Changes in this pull request

- Also display the textual information of the signature next to the graphic.
- Demonstrate how to supply fonts so that if Helvetica is available on the system, it is available for subsetting during appearance generation.

#### Fulfills  [DLPJTS-115](https://jira.datalogics.com/browse/DLPJTS-115)

#### Checklist for approving this pull request

(PR creator amend this with more conditions if necessary)

- [x] There are **unit tests** for new/changed code, or a good explanation why this was not possible.
- [x] All **CI builders** have indicated success (Give them a few minutes to notice the pull request.)
- [x] The **Pull request title** has the JIRA issue numbers separated by spaces (if any), a space, and then a short, but descriptive summary.
- [x] **Commit messages** are well formed: [A note about Git commit messages](http://www.tpope.net/node/106)
- [x] New public packages, classes, and methods are **documented**. (Strongly consider documenting private classes and methods.)

#### Blockers

Add a checkbox for yourself with your **&#64;name** to this list if you are holding this PR open for review. PR Shepherd, please hold off merging this PR until these are all checked:

- [x] _&lt;add your name here with an **@**>_