### PR TITLE
DLPJTS-25 PDF/A2 conversion sample

### DIFF
--- a/src/main/java/com/datalogics/pdf/samples/manipulation/ConvertToPdfA2.java
+++ b/src/main/java/com/datalogics/pdf/samples/manipulation/ConvertToPdfA2.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2017 Datalogics, Inc.
+ */
+
+package com.datalogics.pdf.samples.manipulation;
+
+import com.adobe.internal.io.ByteWriter;
+import com.adobe.pdfjt.core.exceptions.PDFFontException;
+import com.adobe.pdfjt.core.exceptions.PDFIOException;
+import com.adobe.pdfjt.core.exceptions.PDFInvalidDocumentException;
+import com.adobe.pdfjt.core.exceptions.PDFInvalidParameterException;
+import com.adobe.pdfjt.core.exceptions.PDFSecurityException;
+import com.adobe.pdfjt.core.exceptions.PDFUnableToCompleteOperationException;
+import com.adobe.pdfjt.core.fontset.PDFFontSet;
+import com.adobe.pdfjt.core.license.LicenseManager;
+import com.adobe.pdfjt.pdf.document.PDFDocument;
+import com.adobe.pdfjt.pdf.document.PDFOpenOptions;
+import com.adobe.pdfjt.pdf.document.PDFSaveFullOptions;
+import com.adobe.pdfjt.pdf.document.PDFSaveOptions;
+import com.adobe.pdfjt.services.pdfa2.PDFA2ConformanceLevel;
+import com.adobe.pdfjt.services.pdfa2.PDFA2ConversionOptions;
+import com.adobe.pdfjt.services.pdfa2.PDFA2ConversionOptionsFactory;
+import com.adobe.pdfjt.services.pdfa2.PDFA2DefaultConversionHandler;
+import com.adobe.pdfjt.services.pdfa2.PDFA2DefaultValidationHandler;
+import com.adobe.pdfjt.services.pdfa2.PDFA2Service;
+import com.adobe.pdfjt.services.pdfa2.PDFA2ValidationOptions;
+
+import com.datalogics.pdf.document.FontSetLoader;
+import com.datalogics.pdf.samples.util.DocumentUtils;
+import com.datalogics.pdf.samples.util.IoUtils;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.logging.Logger;
+
+/**
+ * This sample demonstrates how to convert a PDF to a PDF/A2 archive file.
+ */
+public final class ConvertToPdfA2 {
+    private static final Logger LOGGER = Logger.getLogger(ConvertToPdfA2.class.getName());
+
+    public static final String INPUT_PDF_PATH = "UnconvertedPdfA2.pdf";
+    public static final String OUTPUT_PDF_PATH = "ConvertedToPdfA2.pdf";
+
+    /**
+     * This is a utility class, and won't be instantiated.
+     */
+    private ConvertToPdfA2() {}
+
+    /**
+     * Main program.
+     *
+     * @param args command line arguments
+     * @throws Exception a general exception was thrown
+     */
+    public static void main(final String... args) throws Exception {
+        // If you are using an evaluation version of the product (License Managed, or LM), set the path to where PDFJT
+        // can find the license file.
+        //
+        // If you are not using an evaluation version of the product you can ignore or remove this code.
+        LicenseManager.setLicensePath(".");
+        URL inputUrl = null;
+        URL outputUrl = null;
+        String conformanceLevelInput = null;
+        PDFA2ConformanceLevel conformanceLevel = PDFA2ConformanceLevel.Level_2b;
+        if (args.length == 3) {
+            inputUrl = IoUtils.createUrlFromPath(args[0]);
+            outputUrl = IoUtils.createUrlFromPath(args[1]);
+            conformanceLevelInput = args[2];
+            if ("a".equals(conformanceLevelInput)) {
+                conformanceLevel = PDFA2ConformanceLevel.Level_2a;
+            } else if ("b".equals(conformanceLevelInput)) {
+                // this isn't necessary since it defaults to 2b, for clarity though it is here
+                conformanceLevel = PDFA2ConformanceLevel.Level_2b;
+            } else if ("u".equals(conformanceLevelInput)) {
+                conformanceLevel = PDFA2ConformanceLevel.Level_2u;
+            } else {
+                throw new IllegalArgumentException("Valid 'a', 'b', or 'u' PDF/A2 conformance level not specified.");
+            }
+        } else {
+            inputUrl = ConvertPdfDocument.class.getResource(INPUT_PDF_PATH);
+            outputUrl = IoUtils.createUrlFromPath(OUTPUT_PDF_PATH);
+        }
+
+        convertToPdfA2(inputUrl, outputUrl, conformanceLevel);
+        validate(outputUrl, conformanceLevel);
+    }
+
+    /**
+     * Converts an input PDF document to the PDF/A-2 standard with the specified conformance level.
+     *
+     * @param inputUrl The URL of the document to be converted
+     * @param outputUrl The URL of the converted document
+     * @throws IOException an I/O operation failed or was interrupted
+     * @throws PDFFontException there was an error in the font set or an individual font
+     * @throws PDFInvalidDocumentException a general problem with the PDF document, which may now be in an invalid state
+     * @throws PDFIOException there was an error reading or writing a PDF file or temporary caches
+     * @throws PDFSecurityException some general security issue occurred during the processing of the request
+     * @throws PDFInvalidParameterException one or more of the parameters passed to a method is invalid
+     * @throws PDFUnableToCompleteOperationException the operation was unable to be completed
+     */
+    public static void convertToPdfA2(final URL inputUrl, final URL outputUrl,
+                                      final PDFA2ConformanceLevel conformanceLevel)
+                    throws IOException, PDFFontException, PDFInvalidDocumentException, PDFIOException,
+                    PDFSecurityException, PDFInvalidParameterException, PDFUnableToCompleteOperationException {
+        ByteWriter writer = null;
+        // Attach font set to PDF
+        final PDFFontSet pdfaFontSet = FontSetLoader.newInstance().getFontSet();
+        final PDFOpenOptions openOptions = PDFOpenOptions.newInstance();
+        openOptions.setFontSet(pdfaFontSet);
+
+        final PDFDocument pdfDoc = DocumentUtils.openPdfDocumentWithOptions(inputUrl, openOptions);
+
+        final PdfA2ConversionHandler handler = new PdfA2ConversionHandler();
+        final PDFA2ConversionOptions options = PDFA2ConversionOptionsFactory.getConfiguredPdfA2bInstance(pdfDoc);
+
+        try {
+            // Attempt to convert the PDF to the supplied PDF/A2 conformance level
+            if (PDFA2Service.convert(pdfDoc, conformanceLevel, options, handler)) {
+                final PDFSaveOptions saveOpt = PDFSaveFullOptions.newInstance();
+
+                writer = IoUtils.newByteWriter(outputUrl);
+                pdfDoc.save(writer, saveOpt);
+
+                final String successMsg = "\nConverted output written to: " + outputUrl.toString();
+                LOGGER.info(successMsg);
+            } else {
+                LOGGER.info("Errors encountered when converting document.");
+            }
+        } finally {
+            if (writer != null) {
+                writer.close();
+            }
+            if (pdfDoc != null) {
+                pdfDoc.close();
+            }
+        }
+    }
+
+    /**
+     * Validates an input PDF document for PDF/A-2 specification with whatever conformance level was supplied.
+     *
+     * @param inputUrl The URL of the document to be validated
+     * @param conformanceLevel The conformance level of the PDF/A-2 spec the document should conform to
+     * @throws PDFInvalidDocumentException a general problem with the PDF document, which may now be in an invalid state
+     * @throws PDFIOException there was an error reading or writing a PDF file or temporary caches
+     * @throws PDFSecurityException some general security issue occurred during the processing of the request
+     * @throws IOException an I/O operation failed or was interrupted
+     * @throws PDFUnableToCompleteOperationException the operation was unable to be completed
+     * @throws PDFInvalidParameterException one or more of the parameters passed to a method is invalid
+     */
+    public static boolean validate(final URL inputUrl, final PDFA2ConformanceLevel conformanceLevel)
+                    throws PDFInvalidDocumentException, PDFIOException, PDFSecurityException, IOException,
+                    PDFUnableToCompleteOperationException, PDFInvalidParameterException {
+        final PDFDocument doc = DocumentUtils.openPdfDocument(inputUrl);
+        final PdfA2ValidationHandler validationHandler = new PdfA2ValidationHandler();
+        final boolean validity = PDFA2Service.validate(doc, conformanceLevel, new PDFA2ValidationOptions(),
+                                                       validationHandler);
+
+        doc.close();
+
+        if (validity) {
+            LOGGER.info("Validation succeeded.");
+        } else {
+            LOGGER.info("Validation failed");
+        }
+        return validity;
+    }
+
+    private static final class PdfA2ConversionHandler extends PDFA2DefaultConversionHandler {
+        @Override
+        public boolean conversionSummary(final boolean fixesApplied, final boolean unfixableFound) {
+            // continue processing unless errors were found
+            return !unfixableFound;
+        }
+    }
+
+    private static final class PdfA2ValidationHandler extends PDFA2DefaultValidationHandler {
+        @Override
+        public boolean endDocumentScan(final boolean errorsFound) {
+            // continue processing unless errors were found
+            return !errorsFound;
+        }
+    }
+}

--- a/src/main/resources/com/datalogics/pdf/samples/manipulation/UnconvertedPdfA2.pdf
+++ b/src/main/resources/com/datalogics/pdf/samples/manipulation/UnconvertedPdfA2.pdf
@@ -1,0 +1,113 @@
+%PDF-1.7
+
+1 0 obj
+<<
+  /Type /Catalog
+  /Pages 3 0 R
+>>
+endobj
+
+% Object 2 is intentionally missing
+
+3 0 obj
+<<
+  /Type /Pages
+  /Kids [4 0 R]
+  /Count 1
+>>
+endobj
+
+4 0 obj
+<<
+  /Type /Page
+  /Parent 3 0 R
+  /MediaBox [0 0 612 396]
+  /Contents [5 0 R 6 0 R]
+  /Resources <<
+    /Font << /F1 7 0 R >>
+  >>
+>>
+endobj
+
+5 0 obj
+<< /Length 747 >>
+stream
+% Save the current graphic state
+q 
+
+% Draw a black line segment, using the default line width.
+150 250 m
+150 350 l
+S
+
+% Draw a thicker, dashed line segment.
+4 w % Set line width to 4 points
+[4 6] 0 d % Set dash pattern to 4 units on, 6 units off
+150 250 m
+400 250 l
+S
+[] 0 d % Reset dash pattern to a solid line
+1 w % Reset line width to 1 unit
+
+% Draw a rectangle with a 1-unit red border, filled with light blue.
+1.0 0.0 0.0 RG % Red for stroke color
+0.5 0.75 1.0 rg % Light blue for fill color
+200 300 50 75 re
+B
+
+% Draw a curve filled with gray and with a colored border.
+0.5 0.1 0.2 RG
+0.7 g
+300 300 m
+300 400 400 400 400 300 c
+b
+
+% Restore the graphic state to what it was at the beginning of this stream
+Q
+
+endstream
+endobj
+
+6 0 obj
+<< /Length 166 >>
+stream
+% A text block that shows "Hello World"
+% No color is set, so this defaults to black in DeviceGray colorspace
+BT
+  /F1 24 Tf
+  100 100 Td
+  (Hello World) Tj
+ET
+endstream
+endobj
+
+7 0 obj
+<<
+  /Type /Font
+  /Subtype /Type1
+  /Name /F1
+  /BaseFont /Helvetica
+>>
+endobj
+
+% The object cross-reference table. The first entry
+% denotes the start of PDF data in this file.
+% Object 2 is a free (unused) object entry.
+xref
+0 8
+0000000000 65535 f
+0000000012 00000 n
+0000000000 00000 f
+0000000112 00000 n
+0000000184 00000 n
+0000000347 00000 n
+0000001152 00000 n
+0000001376 00000 n
+trailer
+<<
+  /Size 8
+  /Root 1 0 R
+>>
+startxref
+1619
+%%EOF

--- a/src/test/java/com/datalogics/pdf/samples/manipulation/ConvertToPdfA2Test.java
+++ b/src/test/java/com/datalogics/pdf/samples/manipulation/ConvertToPdfA2Test.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Datalogics, Inc.
+ */
+
+package com.datalogics.pdf.samples.manipulation;
+
+import static org.junit.Assert.assertTrue;
+
+import com.adobe.pdfjt.services.pdfa2.PDFA2ConformanceLevel;
+
+import com.datalogics.pdf.samples.SampleTest;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URL;
+
+/**
+ * Tests the ConvertToPdfA2 sample.
+ */
+public class ConvertToPdfA2Test extends SampleTest {
+
+    private static final String FILE_NAME = "ConvertedPdfa-2b.pdf";
+
+    @Test
+    public void testConvertToPdfA2B() throws Exception {
+        final URL inputUrl = ConvertToPdfA2.class.getResource(ConvertToPdfA2.INPUT_PDF_PATH);
+        final File outputFile = newOutputFileWithDelete(FILE_NAME);
+        final URL outputUrl = outputFile.toURI().toURL();
+
+        ConvertToPdfA2.convertToPdfA2(inputUrl, outputUrl, PDFA2ConformanceLevel.Level_2b);
+        // Make sure the Output file exists.
+        assertTrue(outputFile.getPath() + " must exist after run", outputFile.exists());
+
+        // Validate the converted document
+        final boolean validity = ConvertToPdfA2.validate(outputUrl, PDFA2ConformanceLevel.Level_2b);
+        assertTrue(outputFile.getPath() + " must be pdfa2-b compliant", validity);
+    }
+}


### PR DESCRIPTION
#### Changes in this pull request

- Adds new sample demonstrating converting a document to PDF/A2 (conformance level b by default)
- Test for the sample

#### Fulfills  [DLPJTS-25](https://jira.datalogics.com/browse/DLPJTS-25)

#### Checklist for approving this pull request

(PR creator amend this with more conditions if necessary)

- [ ] There are **unit tests** for new/changed code, or a good explanation why this was not possible.
- [x] All **CI builders** have indicated success (Give them a few minutes to notice the pull request.)
- [ ] The **Pull request title** has the JIRA issue numbers separated by spaces (if any), a space, and then a short, but descriptive summary.
- [ ] **Commit messages** are well formed: [A note about Git commit messages](http://www.tpope.net/node/106)
- [ ] New public packages, classes, and methods are **documented**. (Strongly consider documenting private classes and methods.)

#### Blockers

Add a checkbox for yourself with your **&#64;name** to this list if you are holding this PR open for review. PR Shepherd, please hold off merging this PR until these are all checked:

- [x] _&lt;add your name here with an **@**>_
