### PR TITLE
[WIP] DLPJTS-130 Sample to add password protection to a document

### DIFF
--- a/src/main/java/com/datalogics/pdf/samples/security/PasswordProtect.java
+++ b/src/main/java/com/datalogics/pdf/samples/security/PasswordProtect.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Datalogics, Inc.
+ */
+
+package com.datalogics.pdf.samples.security;
+
+import com.adobe.pdfjt.core.license.LicenseManager;
+import com.adobe.pdfjt.pdf.document.PDFDocument;
+import com.adobe.pdfjt.pdf.document.PDFSaveFullOptions;
+import com.adobe.pdfjt.services.security.SecurityLockPassword;
+import com.adobe.pdfjt.services.security.UnicodePasswordUtil;
+
+import com.datalogics.pdf.document.DocumentHelper;
+import com.datalogics.pdf.samples.signature.SignDocument;
+import com.datalogics.pdf.samples.util.DocumentUtils;
+import com.datalogics.pdf.samples.util.IoUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URL;
+
+public class PasswordProtect {
+    public static final String INPUT_UNPROTECTED_PDF_PATH = "/com/datalogics/pdf/samples/manipulation/pdfjavatoolkit-ds.pdf";
+    public static final String OUTPUT_PASSWORD_PROTECTED_PDF_PATH = "PasswordProtected.pdf";
+    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    /**
+     * This is a utility class, and won't be instantiated.
+     */
+    private PasswordProtect() {}
+
+    /**
+     * Main program.
+     *
+     * @param args command line arguments. Only one is expected in order to specify the output path. If no arguments are
+     *        given, the sample will output to the root of the samples directory by default.
+     * @throws Exception a general exception was thrown
+     */
+    public static void main(final String... args) throws Exception {
+        // If you are using an evaluation version of the product (License Managed, or LM), set the path to where PDFJT
+        // can find the license file.
+        //
+        // If you are not using an evaluation version of the product you can ignore or remove this code.
+        LicenseManager.setLicensePath(".");
+
+        URL outputUrl = null;
+        if (args.length > 0) {
+            outputUrl = IoUtils.createUrlFromPath(args[0]);
+        } else {
+            outputUrl = IoUtils.createUrlFromPath(OUTPUT_PASSWORD_PROTECTED_PDF_PATH);
+        }
+
+        final URL inputUrl = SignDocument.class.getResource(INPUT_UNPROTECTED_PDF_PATH);
+
+        // Query and sign all permissible signature fields.
+        passwordProtectDocument(inputUrl, outputUrl, "ownerPassword", "userPassword");
+    }
+
+    public static void passwordProtectDocument(final URL inputUrl, final URL outputUrl, final String ownerPassword,
+                                               final String userPassword)
+                    throws Exception {
+        final PDFDocument pdfDocument = DocumentUtils.openPdfDocument(inputUrl);
+        final UnicodePasswordUtil unicodePasswordUtil = new UnicodePasswordUtil();
+        final byte[] ownerPW = unicodePasswordUtil.getPasswordFromUnicode(ownerPassword);
+        final byte[] userPW = unicodePasswordUtil.getPasswordFromUnicode(userPassword);
+
+        // Metadata should *not* be encrypted
+        final boolean encryptedMetadata = false;
+        final SecurityLockPassword securityLockPassword = SecurityLockPassword.newAES_128bit(pdfDocument,
+                                                                                             ownerPW,
+                                                                                             userPW,
+                                                                                             encryptedMetadata);
+
+        final PDFSaveFullOptions pdfSaveFullOptions = PDFSaveFullOptions.newInstance(securityLockPassword);
+        DocumentHelper.saveAndClose(pdfDocument, outputUrl.toURI().getPath(), pdfSaveFullOptions);
+    }
+
+
+}


### PR DESCRIPTION
#### Changes in this pull request

- Add a sample to add password protection to a document

#### Fulfills  [DLPJTS-130](https://jira.datalogics.com/browse/DLPJTS-130)

#### Checklist for approving this pull request

(PR creator amend this with more conditions if necessary)

- [ ] There are **unit tests** for new/changed code, or a good explanation why this was not possible.
- [ ] All **CI builders** have indicated success (Give them a few minutes to notice the pull request.)
- [ ] The **Pull request title** has the JIRA issue numbers separated by spaces (if any), a space, and then a short, but descriptive summary.
- [ ] **Commit messages** are well formed: [A note about Git commit messages](http://www.tpope.net/node/106)
- [ ] New public packages, classes, and methods are **documented**. (Strongly consider documenting private classes and methods.)

#### Blockers

Add a checkbox for yourself with your **&#64;name** to this list if you are holding this PR open for review. PR Shepherd, please hold off merging this PR until these are all checked:

- [x] _&lt;add your name here with an **@**>_


[DLPJTS-130]: https://datalogics-jira.atlassian.net/browse/DLPJTS-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ