### PR TITLE
DLPJT-336 Suppress cves 2021-37533 and 2023-6378

### DIFF
--- a/owasp-suppressions/owasp-suppressions.xml
+++ b/owasp-suppressions/owasp-suppressions.xml
@@ -21,4 +21,18 @@
         <packageUrl regex="true">^pkg:maven/xerces/xercesImpl@.*$</packageUrl>
         <vulnerabilityName>CVE-2017-10355</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+            file name: commons-io-2.7.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/commons-io/commons-io@.*$</packageUrl>
+        <cve>CVE-2021-37533</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[g
+            file name: logback-classic-1.2.9.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/ch.qos.logback/logback-classic@.*$</packageUrl>
+        <cve>CVE-2023-6378</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
#### Changes in this pull request

- Suppresses CVE-2021-37533 which impacted commons-io.
- Suppresses CVE-2023-6378 which impacted logback-classic.

#### Fulfills  [DLPJT-336](https://jira.datalogics.com/browse/DLPJT-336)

#### Checklist for approving this pull request

(PR creator amend this with more conditions if necessary)

- [x] There are **unit tests** for new/changed code, or a good explanation why this was not possible.
- [x] All **CI builders** have indicated success (Give them a few minutes to notice the pull request.)
- [x] The **Pull request title** has the JIRA issue numbers separated by spaces (if any), a space, and then a short, but descriptive summary.
- [x] **Commit messages** are well formed: [A note about Git commit messages](http://www.tpope.net/node/106)
- [x] New public packages, classes, and methods are **documented**. (Strongly consider documenting private classes and methods.)

#### Blockers

Add a checkbox for yourself with your **&#64;name** to this list if you are holding this PR open for review. PR Shepherd, please hold off merging this PR until these are all checked:

- [x] _&lt;add your name here with an **@**>_


[DLPJT-336]: https://datalogics-jira.atlassian.net/browse/DLPJT-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ