### PR TITLE
Use codex to suggest the correct fix for the old syntax.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,10 +116,13 @@ pipeline {
 
         stage('Analysis') {
             steps {
-                recordIssues ignoreQualityGate: false, qualityGates: [[threshold: 1, type: 'TOTAL', unstable: false]],
+                recordIssues(
+                    ignoreQualityGate: false,
                     enabledForFailure: true,
+                    qualityGates: [[threshold: 1, type: 'TOTAL', unstable: false]],
                     tools: [checkStyle(), findBugs(useRankAsPriority: true), pmdParser(), cpd(), javaDoc(), java(),
                             owaspDependencyCheck()]
+                )
             }
         }
 


### PR DESCRIPTION
#### Changes in this pull request

I gave codex the prompt ` My Jenkins CI run for this Java project is failing.  Read the output and diagnose the problem` - and pasted the nightly build's log into the prompt.  The response was:

• The pipeline never even starts building. Jenkins fails while parsing the Jenkinsfile: the recordIssues step is called with an unsupported
  parameter ignoreFailedBuilds (Jenkinsfile:119). The Warnings NG plugin no longer accepts this argument; the hint shows it expects
  ignoreQualityGate instead.

  Fix: edit the Jenkinsfile and remove ignoreFailedBuilds or replace it with the current parameter (e.g., ignoreQualityGate: false), keeping
  your qualityGates block as-is. After updating the step, the pipeline should parse and run normally.

and I followed up by telling it to fix it 


#### Checklist for approving this pull request

(PR creator amend this with more conditions if necessary)

- [ ] There are **unit tests** for new/changed code, or a good explanation why this was not possible.
- [ ] All **CI builders** have indicated success (Give them a few minutes to notice the pull request.)
- [ ] The **Pull request title** has the JIRA issue numbers separated by spaces (if any), a space, and then a short, but descriptive summary.
- [ ] **Commit messages** are well formed: [A note about Git commit messages](http://www.tpope.net/node/106)
- [ ] New public packages, classes, and methods are **documented**. (Strongly consider documenting private classes and methods.)

#### Blockers

Add a checkbox for yourself with your **&#64;name** to this list if you are holding this PR open for review. PR Shepherd, please hold off merging this PR until these are all checked:

- [x] _&lt;add your name here with an **@**>_
