### PR TITLE
Fix XXE vulnerabilities in FormImporter

### DIFF
--- a/src/main/java/com/datalogics/pdf/samples/forms/FormImporter.java
+++ b/src/main/java/com/datalogics/pdf/samples/forms/FormImporter.java
@@ -38,6 +38,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Locale;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -312,6 +313,9 @@ public final class FormImporter {
         throws ParserConfigurationException, IOException, SAXException {
 
         final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
         final DocumentBuilder builder = factory.newDocumentBuilder();
 
         final Document xmlDoc = builder.parse(inputDataUrl.openStream());
@@ -333,6 +337,9 @@ public final class FormImporter {
         throws ParserConfigurationException, IOException, SAXException {
 
         final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
         final DocumentBuilder builder = factory.newDocumentBuilder();
 
         final Document xmlDoc = builder.parse(inputDataUrl.openStream());
@@ -354,6 +361,9 @@ public final class FormImporter {
         throws ParserConfigurationException, IOException, SAXException, TransformerException {
 
         final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
         final DocumentBuilder builder = factory.newDocumentBuilder();
 
         final Document oldDoc = builder.parse(xfaData);
@@ -365,7 +375,16 @@ public final class FormImporter {
         final Node dataNode = newRoot;
         dataNode.appendChild(newDoc.importNode(oldRoot, true));
 
-        final Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        final TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        try {
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        } catch (final IllegalArgumentException e) {
+            // Some TransformerFactory implementations (e.g. Apache Xalan) do not support these
+            // JAXP 1.5 attributes. In that case, external DTD/stylesheet access is already
+            // restricted by the implementation.
+        }
+        final Transformer transformer = transformerFactory.newTransformer();
         final Result xmlFile = new StreamResult(xfaData);
         final Source newXml = new DOMSource(newDoc);
         transformer.transform(newXml, xmlFile);
@@ -384,6 +403,9 @@ public final class FormImporter {
         throws ParserConfigurationException, TransformerException, IOException, SAXException {
 
         final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
         final DocumentBuilder builder = factory.newDocumentBuilder();
 
         final Document oldDoc = builder.parse(xfaData);
@@ -395,7 +417,16 @@ public final class FormImporter {
         final Node dataNode = newRoot.appendChild(newDoc.createElement(XFA_DATA_CHILD_NODE));
         dataNode.appendChild(newDoc.importNode(oldRoot, true));
 
-        final Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        final TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        try {
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        } catch (final IllegalArgumentException e) {
+            // Some TransformerFactory implementations (e.g. Apache Xalan) do not support these
+            // JAXP 1.5 attributes. In that case, external DTD/stylesheet access is already
+            // restricted by the implementation.
+        }
+        final Transformer transformer = transformerFactory.newTransformer();
         final Result xmlFile = new StreamResult(xfaData);
         final Source newXml = new DOMSource(newDoc);
         transformer.transform(newXml, xmlFile);

--- a/src/main/java/com/datalogics/pdf/samples/forms/FormImporter.java
+++ b/src/main/java/com/datalogics/pdf/samples/forms/FormImporter.java
@@ -26,6 +26,8 @@ import com.datalogics.pdf.document.DocumentHelper;
 import com.datalogics.pdf.samples.util.DocumentUtils;
 import com.datalogics.pdf.samples.util.IoUtils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -34,6 +36,7 @@ import org.xml.sax.SAXException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Locale;
@@ -54,6 +57,13 @@ import javax.xml.transform.stream.StreamResult;
  * Provide support for importing forms.
  */
 public final class FormImporter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    // XXE prevention feature URIs
+    private static final String DISALLOW_DOCTYPE_DECL = "http://apache.org/xml/features/disallow-doctype-decl";
+    private static final String EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
+    private static final String EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
 
     /**
      * Indicate the type of the form.
@@ -313,9 +323,9 @@ public final class FormImporter {
         throws ParserConfigurationException, IOException, SAXException {
 
         final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setFeature(DISALLOW_DOCTYPE_DECL, true);
+        factory.setFeature(EXTERNAL_GENERAL_ENTITIES, false);
+        factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
         final DocumentBuilder builder = factory.newDocumentBuilder();
 
         final Document xmlDoc = builder.parse(inputDataUrl.openStream());
@@ -337,9 +347,9 @@ public final class FormImporter {
         throws ParserConfigurationException, IOException, SAXException {
 
         final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setFeature(DISALLOW_DOCTYPE_DECL, true);
+        factory.setFeature(EXTERNAL_GENERAL_ENTITIES, false);
+        factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
         final DocumentBuilder builder = factory.newDocumentBuilder();
 
         final Document xmlDoc = builder.parse(inputDataUrl.openStream());
@@ -361,9 +371,9 @@ public final class FormImporter {
         throws ParserConfigurationException, IOException, SAXException, TransformerException {
 
         final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setFeature(DISALLOW_DOCTYPE_DECL, true);
+        factory.setFeature(EXTERNAL_GENERAL_ENTITIES, false);
+        factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
         final DocumentBuilder builder = factory.newDocumentBuilder();
 
         final Document oldDoc = builder.parse(xfaData);
@@ -383,6 +393,7 @@ public final class FormImporter {
             // Some TransformerFactory implementations (e.g. Apache Xalan) do not support these
             // JAXP 1.5 attributes. In that case, external DTD/stylesheet access is already
             // restricted by the implementation.
+            LOGGER.debug("TransformerFactory does not support JAXP 1.5 security attributes", e);
         }
         final Transformer transformer = transformerFactory.newTransformer();
         final Result xmlFile = new StreamResult(xfaData);
@@ -403,9 +414,9 @@ public final class FormImporter {
         throws ParserConfigurationException, TransformerException, IOException, SAXException {
 
         final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setFeature(DISALLOW_DOCTYPE_DECL, true);
+        factory.setFeature(EXTERNAL_GENERAL_ENTITIES, false);
+        factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
         final DocumentBuilder builder = factory.newDocumentBuilder();
 
         final Document oldDoc = builder.parse(xfaData);
@@ -425,6 +436,7 @@ public final class FormImporter {
             // Some TransformerFactory implementations (e.g. Apache Xalan) do not support these
             // JAXP 1.5 attributes. In that case, external DTD/stylesheet access is already
             // restricted by the implementation.
+            LOGGER.debug("TransformerFactory does not support JAXP 1.5 security attributes", e);
         }
         final Transformer transformer = transformerFactory.newTransformer();
         final Result xmlFile = new StreamResult(xfaData);


### PR DESCRIPTION
## Summary
- Secure all 4 `DocumentBuilderFactory` instances by disabling DOCTYPE declarations and external entity processing
- Secure both `TransformerFactory` instances by restricting external DTD and stylesheet access, with try-catch fallback for Apache Xalan which does not support JAXP 1.5 attributes
- Resolves 16 high-severity Semgrep SAST findings for XML External Entity (XXE) injection

## Test plan
- [x] Clean compile succeeds
- [x] All 4 FillFormTest tests pass (directly exercises modified code)
- [x] No new test regressions (8 pre-existing failures unrelated to XML parsing)

Generated with [Claude Code](https://claude.com/claude-code)