### PR TITLE
Update to super-pom 3.1.3 for JDK 8 bytecode compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>super-pom</artifactId>
     <groupId>com.datalogics.maven</groupId>
-    <version>3.1.2</version>
+    <version>3.1.3</version>
     <relativePath></relativePath>
   </parent>
   <groupId>com.datalogics.pdf</groupId>
@@ -82,10 +82,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.11.0</version>
-        <configuration>
-          <release>8</release>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
#### Changes in this pull request

- Remove redundant maven-compiler-plugin version and release=8 config, now inherited from super-pom 3.1.3.

#### Fulfills  [PDFJT-1349](https://datalogics-jira.atlassian.net/browse/PDFJT-1349)

#### Checklist for approving this pull request

(PR creator amend this with more conditions if necessary)

- [ ] There are **unit tests** for new/changed code, or a good explanation why this was not possible.
- [ ] All **CI builders** have indicated success (Give them a few minutes to notice the pull request.)
- [ ] The **Pull request title** has the JIRA issue numbers separated by spaces (if any), a space, and then a short, but descriptive summary.
- [ ] **Commit messages** are well formed: [A note about Git commit messages](http://www.tpope.net/node/106)
- [ ] New public packages, classes, and methods are **documented**. (Strongly consider documenting private classes and methods.)

#### Blockers

Add a checkbox for yourself with your **&#64;name** to this list if you are holding this PR open for review. PR Shepherd, please hold off merging this PR until these are all checked:

- [x] _&lt;add your name here with an **@**>_


[PDFJT-1349]: https://datalogics-jira.atlassian.net/browse/PDFJT-1349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ