### PR TITLE
Suppress CVE-2026-66755 for tika-core 1.28.5

### DIFF
--- a/owasp-suppressions/owasp-suppressions.xml
+++ b/owasp-suppressions/owasp-suppressions.xml
@@ -18,4 +18,16 @@
         <packageUrl regex="true">^pkg:maven/org.apache.tika/tika-core@.*$</packageUrl>
         <cve>CVE-2025-54988</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+            file name: tika-core-1.28.5.jar
+            Suppressed upstream in talkeetna. CVE-2026-66755 is a path traversal in
+            Tika's ISATabParser, which ships in tika-parsers; we depend only on
+            tika-core, so the vulnerable code is not on the classpath. Cannot upgrade
+            anyway: fix versions are Tika 3.3.2 (Java 11+) and 4.0.0 (Java 17+), and
+            we must maintain JDK 8 compatibility for users.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org.apache.tika/tika-core@.*$</packageUrl>
+        <cve>CVE-2026-66755</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
#### Changes in this pull request

- Add an OWASP dependency-check suppression for CVE-2026-66755 against `tika-core` 1.28.5 in `owasp-suppressions/owasp-suppressions.xml`.

The nightly `develop` build fails because dependency-check flags CVE-2026-66755 (CVSS 5.9), a relative path traversal in Tika's `ISATabParser`. That parser ships in `tika-parsers`; we depend only on `tika-core`, and `tika-core-1.28.5.jar` contains no ISA-Tab classes, so the vulnerable code is never on our classpath. Upgrading is not an option either way: the fix versions are Tika 3.3.2, which requires Java 11, and 4.0.0, which requires Java 17, and we must keep Java 8 support for customers.

#### Found during nightly job runs -- no Jira case

#### Checklist for approving this pull request

(PR creator amend this with more conditions if necessary)

- [ ] There are **unit tests** for new/changed code, or a good explanation why this was not possible.
- [ ] All **CI builders** have indicated success (Give them a few minutes to notice the pull request.)
- [ ] The **Pull request title** has the JIRA issue numbers separated by spaces (if any), a space, and then a short, but descriptive summary.
- [ ] **Commit messages** are well formed: [A note about Git commit messages](http://www.tpope.net/node/106)
- [ ] New public packages, classes, and methods are **documented**. (Strongly consider documenting private classes and methods.)

#### Blockers

Add a checkbox for yourself with your **&#64;name** to this list if you are holding this PR open for review. PR Shepherd, please hold off merging this PR until these are all checked:

- [x] _&lt;add your name here with an **@**>_
